### PR TITLE
Make sure static type information is up-to-date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           bundler-cache: true
       - name: Run static code analysis
         run: bundle exec rake standard
+      - name: Check static type information
+        run: bundle exec steep check
   unit:
     runs-on: ubuntu-latest
     needs: standard


### PR DESCRIPTION
Run steep in CI to make sure we don't release code with broken static
type information.
