### PR TITLE
Fix missing requirement for uri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,8 @@ gem "rspec", "~> 3.0"
 gem "standard", "~> 1.3"
 
 group :development do
-  gem "steep", require: false
+  # FIXME: Relax this version when the stardand gem can cope with empty collection annotations
+  # https://github.com/soutaro/steep/pull/1338
+  # https://github.com/standardrb/standard/pull/656
+  gem "steep", "< 1.9.0", require: false
 end

--- a/lib/opensearch/cli.rb
+++ b/lib/opensearch/cli.rb
@@ -2,6 +2,7 @@
 
 require "openssl"
 require "optparse"
+require "uri"
 
 module OpenSearch
   class CLI < OptionParser

--- a/lib/opensearch/cli.rb
+++ b/lib/opensearch/cli.rb
@@ -13,7 +13,7 @@ module OpenSearch
         host: "https://localhost:9200",
         transport_options: {ssl: {}}
       }
-      super(banner, width, indent) {}
+      super {}
 
       add_opensearch_options
 


### PR DESCRIPTION
When loading configuration from an option file (using `OpenSearch::CLI#load`, which rely on `OptionParser#load`) and `uri` is not loaded, an undefined method exception is raised when an `url` option is parsed, but that exception is captured by the `OptionParser` logic resulting in the option file to be completely ignored.

While `#load` return false to indicate the failure, consumers of the library are unlikely to check it because end users may or may not rely on option files.

Unconditionally require `uri` to avoid this issue.
